### PR TITLE
Generate doc comments for resulting bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "uniffi_macros",
   "uniffi_meta",
   "uniffi_testing",
+  "uniffi_docs",
   "uniffi",
   "weedle2",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "examples/sprites",
   "examples/todolist",
   "examples/custom-types",
+  "examples/documentation",
 
   "fixtures/coverall",
   "fixtures/callbacks",

--- a/examples/documentation/Cargo.toml
+++ b/examples/documentation/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uniffi-example-documentation"
+edition = "2021"
+version = "0.23.0"
+license = "MPL-2.0"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_documentation"
+
+[dependencies]
+uniffi = { path = "../../uniffi"}
+
+[build-dependencies]
+uniffi = { path = "../../uniffi", features = ["build"] }
+
+[dev-dependencies]
+uniffi = { path = "../../uniffi", features = ["bindgen-tests"] }

--- a/examples/documentation/build.rs
+++ b/examples/documentation/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi::generate_scaffolding("./src/documentation.udl").unwrap();
+}

--- a/examples/documentation/src/documentation.udl
+++ b/examples/documentation/src/documentation.udl
@@ -1,0 +1,8 @@
+namespace documentation {
+  string hello(Person person);
+  u64 add(u64 a, u64 b);
+};
+
+dictionary Person {
+  string name;
+};

--- a/examples/documentation/src/lib.rs
+++ b/examples/documentation/src/lib.rs
@@ -1,0 +1,18 @@
+/// Person with a name.
+pub struct Person {
+    /// Person's name.
+    pub name: String,
+}
+
+/// Create hello message to a `person`.
+pub fn hello(person: Person) -> String {
+    let name = person.name;
+    format!("Hello {name}!")
+}
+
+/// Add two integers together.
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+uniffi::include_scaffolding!("documentation");

--- a/examples/documentation/tests/bindings/test_documentation.kts
+++ b/examples/documentation/tests/bindings/test_documentation.kts
@@ -1,0 +1,4 @@
+import uniffi.documentation.*
+
+assert(hello(Person("Tom")) == "Hello Tom!")
+assert(add(2UL, 4UL) == 6UL)

--- a/examples/documentation/tests/bindings/test_documentation.py
+++ b/examples/documentation/tests/bindings/test_documentation.py
@@ -1,0 +1,16 @@
+import unittest
+import documentation
+
+class TestHello(unittest.TestCase):
+    def test_hello(self):
+        self.assertEqual(documentation.hello(documentation.Person("Tom")),
+                         "Hello Tom!", "Should be `Hello Tom!`")
+
+
+class TestAdd(unittest.TestCase):
+    def test_add(self):
+        self.assertEqual(documentation.add(2, 3), 5, "Should be 5")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/documentation/tests/bindings/test_documentation.rb
+++ b/examples/documentation/tests/bindings/test_documentation.rb
@@ -1,0 +1,12 @@
+require "test/unit"
+require "documentation"
+ 
+class TestAdd < Test::Unit::TestCase
+  def test_hello
+    assert_equal(Documentation.hello(Documentation::Person.new("Tom")), "Hello Tom!")
+  end
+
+  def test_add
+    assert_equal(5, Documentation.add(2, 3))
+  end
+end

--- a/examples/documentation/tests/bindings/test_documentation.swift
+++ b/examples/documentation/tests/bindings/test_documentation.swift
@@ -1,0 +1,4 @@
+import documentation
+
+assert(hello(person: Person(name: "Tom")) == "Hello Tom!", "hello works")
+assert(add(a: 2, b: 4) == 6, "add works")

--- a/examples/documentation/tests/test_generated_bindings.rs
+++ b/examples/documentation/tests/test_generated_bindings.rs
@@ -1,0 +1,6 @@
+uniffi::build_foreign_language_testcases!(
+    "tests/bindings/test_documentation.py",
+    "tests/bindings/test_documentation.rb",
+    "tests/bindings/test_documentation.kts",
+    "tests/bindings/test_documentation.swift",
+);

--- a/examples/documentation/uniffi.toml
+++ b/examples/documentation/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings]
+doc_comments = true

--- a/uniffi_bindgen/Cargo.toml
+++ b/uniffi_bindgen/Cargo.toml
@@ -27,3 +27,4 @@ toml = "0.5"
 weedle2 = { version = "4.0.0", path = "../weedle2" }
 uniffi_meta = { path = "../uniffi_meta", version = "=0.23.0" }
 uniffi_testing = { path = "../uniffi_testing", version = "=0.23.0" }
+uniffi_docs = { path = "../uniffi_docs", version = "=0.23.0" }

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordDocsTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordDocsTemplate.kt
@@ -1,0 +1,8 @@
+
+{% match rec.documentation() -%}
+  {% when Some with (docs) %}
+/**
+* {{ docs.description }}
+*/
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/RecordTemplate.kt
@@ -1,5 +1,6 @@
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 
+{% include "RecordDocsTemplate.kt" %}
 data class {{ type_name }} (
     {%- for field in rec.fields() %}
     var {{ field.name()|var_name }}: {{ field|type_name -}}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFuncDocsTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFuncDocsTemplate.kt
@@ -1,9 +1,20 @@
 
+{% match func.documentation() -%}
+  {% when Some with (docs) %}
 /**
- * fun name: {{func.name()}}
- * Some fun description text. This is supposed to be run with KDoc or Dokka.
-{% for arg in func.arguments() -%}
- * @param[{{ arg.name() }}] description.
-{% endfor %} 
- * @return something something.
- */
+* {{ docs.description }}
+
+    {%- if docs.arguments_descriptions.len() > 0 %}
+*
+    {% for arg in func.arguments() -%}
+* @param[{{ arg.name() }}] description.
+    {% endfor -%} 
+    {% endif -%}
+
+    {%- if docs.return_description.is_some() %}
+*
+* @return something something.
+    {% endif %}
+*/
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/TopLevelFunctionTemplate.kt
@@ -4,13 +4,13 @@
 {%- else -%}
 {%- endmatch %}
 {%- match func.return_type() -%}
-{%- when Some with (return_type) %}
+{%- when Some with (return_type) -%}
 
 fun {{ func.name()|fn_name }}({%- call kt::arg_list_decl(func) -%}): {{ return_type|type_name }} {
     return {{ return_type|lift_fn }}({% call kt::to_ffi_call(func) %})
 }
 
-{% when None %}
+{% when None -%}
 
 fun {{ func.name()|fn_name }}({% call kt::arg_list_decl(func) %}) =
     {% call kt::to_ffi_call(func) %}

--- a/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
+++ b/uniffi_bindgen/src/bindings/kotlin/templates/wrapper.kt
@@ -42,7 +42,7 @@ import java.nio.ByteOrder
 
 {%- for func in ci.function_definitions() %}
 {%- include "TopLevelFuncDocsTemplate.kt" %}
-{%- include "TopLevelFunctionTemplate.kt" %}
+{% include "TopLevelFunctionTemplate.kt" %}
 {%- endfor %}
 
 

--- a/uniffi_bindgen/src/bindings/mod.rs
+++ b/uniffi_bindgen/src/bindings/mod.rs
@@ -66,6 +66,8 @@ impl TryFrom<String> for TargetLanguage {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
+    pub doc_comments: Option<bool>,
+    #[serde(default)]
     kotlin: kotlin::Config,
     #[serde(default)]
     swift: swift::Config,
@@ -78,6 +80,7 @@ pub struct Config {
 impl From<&ComponentInterface> for Config {
     fn from(ci: &ComponentInterface) -> Self {
         Config {
+            doc_comments: None,
             kotlin: ci.into(),
             swift: ci.into(),
             python: ci.into(),
@@ -89,6 +92,7 @@ impl From<&ComponentInterface> for Config {
 impl MergeWith for Config {
     fn merge_with(&self, other: &Self) -> Self {
         Config {
+            doc_comments: self.doc_comments.merge_with(&other.doc_comments),
             kotlin: self.kotlin.merge_with(&other.kotlin),
             swift: self.swift.merge_with(&other.swift),
             python: self.python.merge_with(&other.python),

--- a/uniffi_bindgen/src/bindings/python/templates/RecordDocsTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordDocsTemplate.py
@@ -1,0 +1,7 @@
+{% match rec.documentation() -%}
+  {% when Some with (docs) %}
+    """
+    {{ docs.description }}
+    """
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RecordTemplate.py
@@ -1,5 +1,6 @@
 {%- let rec = ci.get_record_definition(name).unwrap() %}
 class {{ type_name }}:
+    {%- include "RecordDocsTemplate.py" %}
 
     def __init__(self, {% for field in rec.fields() %}
     {{- field.name()|var_name }}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFuncDocsTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFuncDocsTemplate.py
@@ -1,11 +1,21 @@
+{% match func.documentation() -%}
+  {% when Some with (docs) %}
+    """
+    {{ docs.description }}
 
-"""
-fun name: {{func.name()}}
-Some fun description text. This is supposed to be run with Sphinx
-https://docutils.sourceforge.io/rst.html documentation
-Some examples https://docutils.sourceforge.io/docutils/statemachine.py
-{% for arg in func.arguments() -%}
-:Parameter {{ arg.name() }}: arg type
-{% endfor %} 
-:Return:  something something.
-"""
+    {%- if docs.arguments_descriptions.len() > 0 %}
+    
+    Parameters:
+
+    {% for arg in func.arguments() -%}
+    - `{{ arg.name() }}`: description
+    {% endfor %} 
+    {% endif -%}
+
+    {%- if docs.return_description.is_some() %}
+
+    Returns: description
+    {% endif %}
+    """
+  {% when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
+++ b/uniffi_bindgen/src/bindings/python/templates/TopLevelFunctionTemplate.py
@@ -2,12 +2,14 @@
 {%- when Some with (return_type) %}
 
 def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+    {%- include "TopLevelFuncDocsTemplate.py" %}
     {%- call py::setup_args(func) %}
     return {{ return_type|lift_fn }}({% call py::to_ffi_call(func) %})
 
 {% when None %}
 
 def {{ func.name()|fn_name }}({%- call py::arg_list_decl(func) -%}):
+    {%- include "TopLevelFuncDocsTemplate.py" %}
     {%- call py::setup_args(func) %}
     {% call py::to_ffi_call(func) %}
 {% endmatch %}

--- a/uniffi_bindgen/src/bindings/python/templates/wrapper.py
+++ b/uniffi_bindgen/src/bindings/python/templates/wrapper.py
@@ -43,7 +43,6 @@ DEFAULT = object()
 {{ type_helper_code }}
 
 {%- for func in ci.function_definitions() %}
-{%- include "TopLevelFuncDocsTemplate.py" %}
 {%- include "TopLevelFunctionTemplate.py" %}
 {%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordDocsTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordDocsTemplate.rb
@@ -1,0 +1,6 @@
+{% match rec.documentation() -%}
+  {% when Some with (docs) %}
+  #
+  # {{ docs.description }}
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/RecordTemplate.rb
@@ -1,4 +1,5 @@
 # Record type {{ rec.name() }}
+{%- include "RecordDocsTemplate.rb" %}
 class {{ rec.name()|class_name_rb }}
   attr_reader {% for field in rec.fields() %}:{{ field.name()|var_name_rb }}{% if loop.last %}{% else %}, {% endif %}{%- endfor %}
 

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFuncDocsTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFuncDocsTemplate.rb
@@ -1,8 +1,17 @@
 
-# {{func.name()}}
-# Place for function description
-# this inline documentation is to be run with YARD for Ruby
-{% for arg in func.arguments() -%}
-# @param {{ arg.name() }} [ .. ] description
-{% endfor %} 
-# @return [FunctionReturnValue] return field description
+{% match func.documentation() -%}
+  {% when Some with (docs) %}
+  # {{ docs.description }}
+
+    {%- if docs.arguments_descriptions.len() > 0 %}
+  # 
+    {% for arg in func.arguments() -%}
+  # @param {{ arg.name() }} [ArgType] description
+    {% endfor %} 
+    {% endif -%}
+
+    {%- if docs.return_description.is_some() %}
+  # @return [FunctionReturnValue] return field description
+    {% endif %}
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
+++ b/uniffi_bindgen/src/bindings/ruby/templates/TopLevelFunctionTemplate.rb
@@ -1,5 +1,5 @@
 {%- match func.return_type() -%}
-{%- when Some with (return_type) %}
+{%- when Some with (return_type) -%}
 
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) -%})
   {%- call rb::coerce_args(func) %}
@@ -7,7 +7,7 @@ def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) -%})
   return {{ "result"|lift_rb(return_type) }}
 end
 
-{% when None %}
+{% when None -%}
 
 def self.{{ func.name()|fn_name_rb }}({%- call rb::arg_list_decl(func) -%})
   {%- call rb::coerce_args(func) %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordDocsTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordDocsTemplate.swift
@@ -1,0 +1,5 @@
+{% match rec.documentation() -%}
+  {% when Some with (docs) %}
+/// {{ docs.description }}
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/RecordTemplate.swift
@@ -1,4 +1,5 @@
 {%- let rec = ci.get_record_definition(name).unwrap() %}
+{% include "RecordDocsTemplate.swift" %}
 public struct {{ type_name }} {
     {%- for field in rec.fields() %}
     public var {{ field.name()|var_name }}: {{ field|type_name }}

--- a/uniffi_bindgen/src/bindings/swift/templates/TopLevelFuncDocsTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/TopLevelFuncDocsTemplate.swift
@@ -1,8 +1,19 @@
 
-/// fun name: {{func.name()}}
-/// for help: https://developer.apple.com/documentation/docc
+{% match func.documentation() -%}
+  {% when Some with (docs) %}
+/// {{ docs.description }}
+
+    {%- if docs.arguments_descriptions.len() > 0 %}
+/// 
 /// - Parameters:
-{%- for arg in func.arguments() %}
-///   - {{ arg.name() }}: argument description
-{% endfor %}
+    {% for arg in func.arguments() -%}
+///     - {{ arg.name() }}: argument description
+    {% endfor -%} 
+    {% endif -%}
+
+    {%- if docs.return_description.is_some() %}
+///
 /// - Returns: The sloth's energy level after eating.
+    {% endif %}
+  {%- when None %}
+{%- endmatch %}

--- a/uniffi_bindgen/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/TopLevelFunctionTemplate.swift
@@ -1,5 +1,5 @@
 {%- match func.return_type() -%}
-{%- when Some with (return_type) %}
+{%- when Some with (return_type) -%}
 
 public func {{ func.name()|fn_name }}({%- call swift::arg_list_decl(func) -%}) {% call swift::throws(func) %} -> {{ return_type|type_name }} {
     return {% call swift::try(func) %} {{ return_type|lift_fn }}(
@@ -7,7 +7,7 @@ public func {{ func.name()|fn_name }}({%- call swift::arg_list_decl(func) -%}) {
     )
 }
 
-{% when None %}
+{% when None -%}
 
 public func {{ func.name()|fn_name }}({% call swift::arg_list_decl(func) %}) {% call swift::throws(func) %} {
     {% call swift::to_ffi_call(func) %}

--- a/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/wrapper.swift
@@ -21,7 +21,7 @@ import {{ config.ffi_module_name() }}
 
 {%- for func in ci.function_definitions() %}
 {%- include "TopLevelFuncDocsTemplate.swift" %}
-{%- include "TopLevelFunctionTemplate.swift" %}
+{% include "TopLevelFunctionTemplate.swift" %}
 {%- endfor %}
 
 /**

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -51,6 +51,8 @@ use super::{convert_type, APIConverter, ComponentInterface};
 #[derive(Debug, Clone, Checksum)]
 pub struct Function {
     pub(super) name: String,
+    #[checksum_ignore]
+    pub(super) documentation: Option<uniffi_docs::Function>,
     pub(super) arguments: Vec<Argument>,
     pub(super) return_type: Option<Type>,
     // We don't include the FFIFunc in the hash calculation, because:
@@ -67,6 +69,10 @@ pub struct Function {
 impl Function {
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn documentation(&self) -> Option<&uniffi_docs::Function> {
+        self.documentation.as_ref()
     }
 
     pub fn arguments(&self) -> Vec<&Argument> {
@@ -138,6 +144,7 @@ impl From<uniffi_meta::FnMetadata> for Function {
 
         Self {
             name: meta.name,
+            documentation: None,
             arguments,
             return_type,
             ffi_func,
@@ -163,6 +170,7 @@ impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> 
                 None => bail!("anonymous functions are not supported {:?}", self),
                 Some(id) => id.0.to_string(),
             },
+            documentation: None,
             return_type,
             arguments: self.args.body.list.convert(ci)?,
             ffi_func: Default::default(),

--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -771,6 +771,23 @@ impl ComponentInterface {
         }
         Ok(())
     }
+
+    /// Attach documentation to structs/"objects"/enums/functions.
+    ///
+    /// Documentation comments in the resulting bindings are based on this information.
+    pub fn attach_documentation(&mut self, mut documentation: uniffi_docs::Documentation) {
+        for (_, record) in self.records.iter_mut() {
+            if let Some(doc) = documentation.structures.remove(record.name()) {
+                record.documentation = Some(doc);
+            }
+        }
+
+        for function in self.functions.iter_mut() {
+            if let Some(doc) = documentation.functions.remove(function.name()) {
+                function.documentation = Some(doc);
+            }
+        }
+    }
 }
 
 fn get_or_insert_object<'a>(objects: &'a mut Vec<Object>, name: &str) -> &'a mut Object {

--- a/uniffi_bindgen/src/lib.rs
+++ b/uniffi_bindgen/src/lib.rs
@@ -302,6 +302,12 @@ pub fn generate_bindings(
     let crate_root = &guess_crate_root(udl_file).context("Failed to guess crate root")?;
 
     let config = get_config(&component, crate_root, config_file_override)?;
+    if config.bindings.doc_comments.unwrap_or_default() {
+        let path = udl_file.with_file_name("lib.rs");
+        let documentation = uniffi_docs::extract_documentation(&path)?;
+        component.attach_documentation(documentation);
+    }
+
     let out_dir = get_out_dir(udl_file, out_dir_override)?;
     for language in target_languages {
         bindings::write_bindings(

--- a/uniffi_docs/Cargo.toml
+++ b/uniffi_docs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "uniffi_docs"
+version = "0.23.0"
+edition = "2021"
+description = "uniffi_meta"
+homepage = "https://mozilla.github.io/uniffi-rs"
+repository = "https://github.com/eigerco/uniffi-rs"
+license = "MPL-2.0"
+keywords = ["ffi", "bindgen", "docs"]
+
+[dependencies]
+anyhow = "1"
+camino = "1.0.8"
+syn = { version = "1.0", features = ["full"] }

--- a/uniffi_docs/src/lib.rs
+++ b/uniffi_docs/src/lib.rs
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{collections::HashMap, fs::read_to_string};
+
+use anyhow::Result;
+use camino::Utf8Path;
+use syn::Attribute;
+
+/// Function documentation.
+#[derive(Debug, Clone)]
+pub struct Function {
+    pub description: String,
+    pub arguments_descriptions: HashMap<String, String>,
+    pub return_description: Option<String>,
+}
+
+/// Structure or enum documentation.
+#[derive(Debug, Clone)]
+pub struct Structure {
+    pub description: String,
+}
+
+/// Impl documentation.
+#[derive(Debug, Clone)]
+pub struct Impl {
+    pub methods: HashMap<String, Function>,
+}
+
+#[derive(Debug)]
+pub struct Documentation {
+    pub functions: HashMap<String, Function>,
+    pub structures: HashMap<String, Structure>,
+    pub impls: HashMap<String, Impl>,
+}
+
+/// Extract doc comment from attributes.
+///
+/// Rust doc comments are silently converted (during parsing) to attributes of form:
+/// #[doc = "documentation comment content"]
+fn extract_doc_comment(attrs: &[Attribute]) -> Option<String> {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            attr.parse_meta().ok().and_then(|meta| {
+                if let syn::Meta::NameValue(named_value) = meta {
+                    let is_doc = named_value.path.is_ident("doc");
+                    if is_doc {
+                        match named_value.lit {
+                            syn::Lit::Str(comment) => Some(comment.value().trim().to_string()),
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        })
+        .next()
+}
+
+/// Extract code documentation comments from Rust `lib.rs` file.
+pub fn extract_documentation(path: &Utf8Path) -> Result<Documentation> {
+    let input = read_to_string(path)?;
+    let file = syn::parse_file(&input)?;
+
+    let mut functions = HashMap::new();
+    let mut structures = HashMap::new();
+    let mut impls = HashMap::new();
+
+    for item in file.items.into_iter() {
+        match item {
+            syn::Item::Enum(item) => {
+                let name = item.ident.to_string();
+                let description = extract_doc_comment(&item.attrs);
+                if let Some(description) = description {
+                    structures.insert(name, Structure { description });
+                }
+            }
+            syn::Item::Struct(item) => {
+                let name = item.ident.to_string();
+                let description = extract_doc_comment(&item.attrs);
+                if let Some(description) = description {
+                    structures.insert(name, Structure { description });
+                }
+            }
+            syn::Item::Impl(item) => {
+                if item.trait_.is_none() {
+                    if let syn::Type::Path(path) = *item.self_ty {
+                        let name = path.path.segments[0].ident.to_string();
+
+                        let methods = item
+                            .items
+                            .into_iter()
+                            .filter_map(|item| {
+                                if let syn::ImplItem::Method(method) = item {
+                                    let name = method.sig.ident.to_string();
+                                    extract_doc_comment(&method.attrs).map(|doc| (name, doc))
+                                } else {
+                                    None
+                                }
+                            })
+                            .map(|(name, description)| {
+                                // todo: parse markdown to extract argument descriptions and return description
+                                (
+                                    name,
+                                    Function {
+                                        description,
+                                        arguments_descriptions: HashMap::new(),
+                                        return_description: None,
+                                    },
+                                )
+                            })
+                            .collect();
+
+                        impls.insert(name, Impl { methods });
+                    }
+                }
+            }
+            syn::Item::Fn(item) => {
+                let name = item.sig.ident.to_string();
+                let description = extract_doc_comment(&item.attrs);
+                if let Some(description) = description {
+                    functions.insert(
+                        name,
+                        Function {
+                            description,
+                            arguments_descriptions: HashMap::new(),
+                            return_description: None,
+                        },
+                    );
+                }
+            }
+            _ => (), // other item types are ignored for now,
+        }
+    }
+
+    Ok(Documentation {
+        functions,
+        structures,
+        impls,
+    })
+}


### PR DESCRIPTION
Implemented in this PR:
- extracts doc comments from `lib.rs` file accompanying `.udl` file,
- attaches doc comments to generated bindings.

Example excerpt from resulting bindings code:

```kt
/**
 * Add two integers together.
 */
fun `add`(`a`: ULong, `b`: ULong): ULong {
    return FfiConverterULong.lift(
        rustCall() { _status ->
            _UniFFILib.INSTANCE.simple_35d3_add(FfiConverterULong.lower(`a`), FfiConverterULong.lower(`b`), _status)
        },
    )
}
```
Based on:
```rust
/// Add two integers together.
pub fn add(left: u64, right: u64) -> u64 {
    simple::add(left, right)
}
``` 